### PR TITLE
feat(events): Add broadcaster_user_id to SubscribeEventsInput

### DIFF
--- a/api_events.go
+++ b/api_events.go
@@ -60,10 +60,13 @@ type (
 		Type    string `json:"name"`
 		Version int    `json:"version"`
 	}
-
+	
 	SubscribeEventsInput struct {
-		Events []EventInput                               `json:"events"`
-		Method optional.Optional[EventSubscriptionMethod] `json:"method,omitempty"`
+		// BroadcasterUserID is the ID of the user for whom the event subscription is being created.
+		// This field is required to specify which channel's events to subscribe to.
+		BroadcasterUserID int                                        `json:"broadcaster_user_id"`
+		Events            []EventInput                               `json:"events"`
+		Method            optional.Optional[EventSubscriptionMethod] `json:"method,omitempty"`
 	}
 
 	SubscribeEventsOutput struct {

--- a/api_events_test.go
+++ b/api_events_test.go
@@ -1,0 +1,31 @@
+package kicksdk
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/glichtv/kick-sdk/optional"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSubscribeEventsInput_IncludesBroadcasterID verifies that the BroadcasterUserID field
+// is correctly serialized into the JSON payload when the SubscribeEventsInput struct is marshaled.
+// This ensures the API request body is compliant with the Kick API documentation.
+func TestSubscribeEventsInput_IncludesBroadcasterID(t *testing.T) {
+
+	testUserID := 987654321
+	input := SubscribeEventsInput{
+		BroadcasterUserID: testUserID,
+		Events: []EventInput{
+			{Type: "chat.message.sent", Version: 1},
+		},
+		Method: optional.From("webhook"),
+	}
+
+	jsonData, err := json.Marshal(input)
+	assert.NoError(t, err)
+
+	jsonString := string(jsonData)
+	assert.Contains(t, jsonString, `"broadcaster_user_id":987654321`)
+	assert.Contains(t, jsonString, `"method":"webhook"`)
+}


### PR DESCRIPTION
Hello,

This PR fixes an issue where event subscriptions would fail silently because a required parameter was missing from the request body.

Problem:
The official Kick API documentation for POST /public/v1/events/subscriptions includes the broadcaster_user_id field. The current SubscribeEventsInput struct in the SDK is missing this field, causing subscription calls to not register correctly.

Solution:
This change adds the BroadcasterUserID field to the SubscribeEventsInput struct, aligning the SDK with the official API documentation.

A new unit test (TestSubscribeEventsInput_IncludesBroadcasterID) has been added to verify that the new field is correctly serialized into the JSON payload. Professional GoDoc comments have also been added to the modified structs.

Thanks!